### PR TITLE
Fix: Disable turbo for sign in buttom

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,7 +5,7 @@
 
   <%- if devise_mapping.omniauthable? %>
     <%- resource_class.omniauth_providers.each do |provider| %>
-      <%= button_to(omniauth_authorize_path(resource_name, provider), html_options = { class: "btn-#{provider}" }) do %>
+      <%= button_to(omniauth_authorize_path(resource_name, provider), html_options = { class: "btn-#{provider}", data: { turbo: false } }) do %>
         <span class="icon-social-gp"></span>
         <span class="title-socials title-<%= provider %>">Sign in with <%= OmniAuth::Utils.camelize(provider) %></span>
         <div class="caption">clique aqui</div>

--- a/lib/gull/version.rb
+++ b/lib/gull/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Gull
-  VERSION = '2.0.0.1'
+  VERSION = '2.0.1'
 end


### PR DESCRIPTION
Disable turbo to avoid CORS error when interacting with the sign in buttom as turbo behaviour tries to replace the form submission to a "inline" request but its domain is blocked by google.

> Access to fetch at 'https://accounts.google.com/o/oauth2/auth?...' (redirected from 'https://...) from origin 'https://...' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.
